### PR TITLE
Updated README

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,12 +60,14 @@ to execute a `SPARQL` query, you need to specify the `type` as
 `sparql`:
 ```
 > df <- query(conn, dataset="bryon/odin-2015-2016", type="sparql", query='
-+ PREFIX : <http://data.world/bryon/odin-2015-2016/ODIN-2015-2016-raw.csv/ODIN-2015-2016-raw#>
-+ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
-+ SELECT * WHERE {
-+    [ :Year ?year ; :Region ?region ; :Overall_subscore ?score ]
-+    FILTER(?year = "2015")
-+ } LIMIT 10')
+PREFIX : <http://data.world/bryon/odin-2015-2016/ODIN-2015-2016-raw.csv/ODIN-2015-2016-raw#>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+SELECT *
+WHERE {
+  [ :Year ?year ; :Region ?region ; :Overall_subscore ?score ]
+  FILTER(?year = "2015")
+} 
+LIMIT 10')
 > df
 # A tibble: 10 × 3
     year         region score


### PR DESCRIPTION
Updated SPARQL query section of README

I changed this portion of the R code block, so that it is more copy/pasteable. As it was written before, the code block would only work if copied/pasted directly into the R console. But this way the copy/paste will work whether the user pastes it into the R console ('+'s will be added automatically) or into a .R script file (the '+'s formed a bad request when I tried from an .R script file).

I also divided SELECT, WHERE, and LIMIT keyword blocks into individual sections, which is totally just a preference thing, but I also think it reads easier.