### PR TITLE
Update README with new branch name

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ title and description for your insight.
 
 To install directly from GitHub:
 ```R
-devtools::install_github("datadotworld/data.world-r", build_vignettes = TRUE)
+devtools::install_github("datadotworld/data.world-r", build_vignettes = TRUE, ref = "main")
 ```
 
 **Note:** You will need to have the devtools package for R installed to run the previous command.  If that is not already installed, you can install it from CRAN using the command:


### PR DESCRIPTION
`ref` defaults to `master` according to the documentation: https://www.rdocumentation.org/packages/devtools/versions/1.13.6/topics/install_github

When using `install_github` with the new branch name of `main`, we will need to include the `ref` manually.